### PR TITLE
enhanced paged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # agon-vdp
 
-Part of the official firmware for the [Agon Console8](https://www.heber.co.uk/agon-console8)
+Part of the official Agon Platform organisation firmware for all Agon computers.
 
-This firmware is intended for use on all Agon Light hardware.  It is primarily developed and tested on the Agon Console8, but is also tested on the Olimex Agon Light 2 and is fully compatible with all Agon Light compatible computers.
+This firmware is intended for use on any Agon Light compatible computer.
 
-This version of agon-vdp may differ from the [Quark firmware](https://github.com/breakintoprogram/agon-vdp) and contain some extensions.  Software written for the Quark firmware should be fully compatible with this version.
+The Agon Platform firmware is a fork from the original [official Quark firmware](https://github.com/breakintoprogram/agon-vdp) for the Agon Light.  It contains many extensions and bug fixes.  Software written to run on Quark firmware should be fully compatible with Agon Platform releases.
 
 ### What is the Agon
 
-Agon is a modern, fully open-source, 8-bit microcomputer and microcontroller in one small, low-cost board. As a computer, it is a standalone device that requires no host PC: it puts out its own video (VGA), audio (2 identical mono channels), accepts a PS/2 keyboard and has its own mass-storage in the form of a µSD card.  The Agon Console8 adds to this a second PS/2 port for attaching a keyboard, and two Atari-style joystick ports.
+Agon is a modern, fully open-source, 8-bit microcomputer and microcontroller in one small, low-cost board. As a computer, it is a standalone device that requires no host PC: it puts out its own video (VGA), audio (2 identical mono channels), accepts a PS/2 keyboard and has its own mass-storage in the form of a µSD card.  The [Agon Console8](https://www.heber.co.uk/agon-console8) adds to this a second PS/2 port for attaching a keyboard, and two Atari-style joystick ports.
 
 https://www.thebyteattic.com/p/agon.html
 
@@ -26,7 +26,7 @@ The VDP also handles the interfaces to the PS/2 keyboard and mouse, and the audi
 
 ### Documentation
 
-The AGON documentation can now be found on the [Community Documentation](https://agonconsole8.github.io/agon-docs/) site.  This site provides extensive documentation about the Agon platform firmware, covering both Quark and Console8 firmware releases.
+The AGON documentation can now be found on the [Community Documentation](https://agonplatform.github.io/agon-docs/) site.  This site provides extensive documentation about the Agon platform firmware, covering all Quark, Agon Console8, and Agon Platform firmware releases.
 
 ### Building
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board_build.f_cpu = 240000000L
 board_build.f_flash = 80000000L
 framework = arduino
 lib_deps =
-    https://github.com/AgonConsole8/vdp-gl.git#firm-sprites
+    https://github.com/AgonPlatform/vdp-gl.git#firm-sprites
     fbiego/ESP32Time@^2.0.0
     robtillaart/CRC@^1.0.3
 build_unflags = -Os

--- a/video/agon.h
+++ b/video/agon.h
@@ -65,6 +65,7 @@
 #define VDP_AFFINE_TRANSFORM	0x96	// Set affine transform
 #define VDP_CONTROLKEYS			0x98	// Control keys on/off
 #define VDP_CHECKKEY			0x99	// Request updated keyboard data for a key
+#define VDP_TEMP_PAGED_MODE		0x9A	// Emable temporary paged mode
 #define VDP_BUFFER_PRINT		0x9B	// Print a buffer of characters literally with no command interpretation
 #define VDP_TEXT_VIEWPORT		0x9C	// Set text viewport using current graphics coordinates
 #define VDP_GRAPHICS_VIEWPORT	0x9D	// Set graphics viewport using current graphics coordinates
@@ -485,6 +486,15 @@ enum class VDUProcessorState {
 	WaitingForFrames,		// Waiting for a number of frames to be processed
 	PagedModePaused,		// Paused in paged mode
 	CtrlShiftPaused			// Paused in Ctrl+Shift mode
+};
+
+// Paged mode states
+//
+enum class PagedMode : uint8_t {
+	Disabled = 0,
+	Enabled = 1,
+	TempEnabled_Disabled = 2,
+	TempEnabled_Enabled = 3,
 };
 
 // Additional modelines

--- a/video/agon.h
+++ b/video/agon.h
@@ -478,6 +478,15 @@ enum class TerminalState {
 	Resuming
 };
 
+// VDU command processor states
+//
+enum class VDUProcessorState {
+	Active,					// Available to process commands
+	WaitingForFrames,		// Waiting for a number of frames to be processed
+	PagedModePaused,		// Paused in paged mode
+	CtrlShiftPaused			// Paused in Ctrl+Shift mode
+};
+
 // Additional modelines
 //
 #ifndef VGA_640x240_60Hz

--- a/video/agon_ps2.h
+++ b/video/agon_ps2.h
@@ -14,6 +14,7 @@ uint8_t			_modifiers = 0;					// Last pressed key modifiers
 uint16_t		kbRepeatDelay = 500;			// Keyboard repeat delay ms (250, 500, 750 or 1000)		
 uint16_t		kbRepeatRate = 100;				// Keyboard repeat rate ms (between 33 and 500)
 uint8_t			kbRegion = 0;					// Keyboard region
+bool			kbEnabled = false;				// Keyboard enabled
 
 bool			mouseEnabled = false;			// Mouse enabled
 uint8_t			mSampleRate = MOUSE_DEFAULT_SAMPLERATE;	// Mouse sample rate
@@ -58,6 +59,7 @@ void setupKeyboardAndMouse() {
 	kb->setLayout(&fabgl::UKLayout);
 	kb->setCodePage(fabgl::CodePages::get(1252));
 	kb->setTypematicRateAndDelay(kbRepeatRate, kbRepeatDelay);
+	kbEnabled = true;
 	resetMousePositioner(canvasW, canvasH, _VGAController.get());
 }
 
@@ -212,6 +214,21 @@ bool wait_shiftkey(uint8_t *ascii, uint8_t* vk, uint8_t* down) {
 	} while (!item.SHIFT);
 
 	return true;
+}
+
+bool shiftKeyPressed() {
+	auto kb = getKeyboard();
+	fabgl::VirtualKeyItem item;
+	return kb->isVKDown(fabgl::VK_LSHIFT) || kb->isVKDown(fabgl::VK_RSHIFT);
+}
+
+bool ctrlKeyPressed() {
+	if (!kbEnabled) {
+		return false;
+	}
+	auto kb = getKeyboard();
+	fabgl::VirtualKeyItem item;
+	return kb->isVKDown(fabgl::VK_LCTRL) || kb->isVKDown(fabgl::VK_RCTRL);
 }
 
 void getKeyboardState(uint16_t *repeatDelay, uint16_t *repeatRate, uint8_t *ledState) {

--- a/video/context.h
+++ b/video/context.h
@@ -129,7 +129,6 @@ class Context {
 		void cursorEndCol();
 		void cursorEndCol(Point * cursor, Rect * viewport);
 
-		bool cursorScrollOrWrap();
 		void cursorAutoNewline();
 		void ensureCursorInViewport(Rect viewport);
 
@@ -222,6 +221,8 @@ class Context {
 		void cursorTab(uint8_t x, uint8_t y);
 		void cursorRelativeMove(int8_t x, int8_t y);
 		void getCursorTextPosition(uint8_t * x, uint8_t * y);
+		bool cursorScrollOrWrap();
+		void resetPagedModeCount();
 
 		// Viewport management functions
 		void viewportReset();

--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -4,8 +4,6 @@
 #include <fabgl.h>
 
 #include "agon_ps2.h"
-// TODO remove this, somehow
-#include "vdp_protocol.h"
 
 // Definitions for the functions we're implementing here
 #include "context.h"
@@ -424,11 +422,11 @@ void Context::cursorDown(bool moveOnly) {
 	if (ctrlKeyPressed()) {
 		if (shiftKeyPressed()) {
 			setProcessorState(VDUProcessorState::CtrlShiftPaused);
-		} else {
-			// TODO make frame countdown values (3 and current) VDP variables
-			setWaitForFrames(3);
+			return;
+		} else if (cursorCtrlPauseFrames > 0) {
+			setWaitForFrames(cursorCtrlPauseFrames);
+			return;
 		}
-		return;
 	}
 	//
 	// Check if scroll required
@@ -561,8 +559,7 @@ void Context::resetPagedModeCount() {
 	uint8_t x, y;
 	auto pageRows = getNormalisedViewportCharHeight();
 	getCursorTextPosition(&x, &y);
-	// TODO consider making the context size (6 rows) a VDP variable
-	pagedModeCount = max(pageRows - y, pageRows - 6);
+	pagedModeCount = max(pageRows - y, pageRows - pagedModeContext);
 }
 
 uint8_t Context::getCharsRemainingInLine() {

--- a/video/context/cursor.h
+++ b/video/context/cursor.h
@@ -10,9 +10,6 @@
 // Definitions for the functions we're implementing here
 #include "context.h"
 
-extern bool			pagedModePause;			// Paged mode pause
-extern uint			waitForFrames;			// Wait for frames (countdown)
-
 // Private cursor management functions
 //
 
@@ -394,14 +391,17 @@ void Context::cursorDown(bool moveOnly) {
 	if (textCursorActive() && pagedMode) {
 		pagedModeCount--;
 		if (pagedModeCount <= 0) {
-			pagedModePause = true;
-			resetPagedModeCount();
+			setProcessorState(VDUProcessorState::PagedModePaused);
 			return;
 		}
 	}
 	if (ctrlKeyPressed()) {
-		// TODO consider making this a VDP Variable
-		waitForFrames = 3;
+		if (shiftKeyPressed()) {
+			setProcessorState(VDUProcessorState::CtrlShiftPaused);
+		} else {
+			// TODO make frame countdown values (3 and current) VDP variables
+			setWaitForFrames(3);
+		}
 		return;
 	}
 	//

--- a/video/vdp_protocol.h
+++ b/video/vdp_protocol.h
@@ -29,20 +29,4 @@ void setupVDPProtocol() {
 	VDPSerial.setTimeout(COMMS_TIMEOUT);
 }
 
-// TODO remove the following - it's only here for cursor.h to send escape key when doing paged mode handling
-
-inline void writeByte(uint8_t b) {
-	VDPSerial.write(b);
-}
-
-// Send a packet of data to the MOS
-//
-void send_packet(uint8_t code, uint16_t len, uint8_t data[]) {
-	writeByte(code + 0x80);
-	writeByte(len);
-	for (int i = 0; i < len; i++) {
-		writeByte(data[i]);
-	}
-}
-
 #endif // AGON_VDP_PROTOCOL_H

--- a/video/vdu.h
+++ b/video/vdu.h
@@ -111,10 +111,10 @@ void VDUStreamProcessor::vdu(uint8_t c, bool usePeek) {
 			context->cursorCR();
 			break;
 		case 0x0E:	// Paged mode ON
-			context->setPagedMode(true);
+			context->setPagedMode(PagedMode::Enabled);
 			break;
 		case 0x0F:	// Paged mode OFF
-			context->setPagedMode(false);
+			context->setPagedMode(PagedMode::Disabled);
 			break;
 		case 0x10:	// CLG
 			context->clg();
@@ -195,7 +195,8 @@ void VDUStreamProcessor::vdu_print(char c, bool usePeek) {
 	s += c;
 	// gather our string for printing
 	if (usePeek) {
-		auto limit = 15;
+		// For compatibility with newline things, we max out to the remaining chars in line
+		auto limit = fabgl::imin(15, getContext()->getCharsRemainingInLine());
 		while (--limit) {
 			if (!byteAvailable()) {
 				break;

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -54,6 +54,8 @@ class VDUStreamProcessor {
 		inline void clearEcho();
 		void flushEcho();
 
+		void handleKeyboardAndMouse();
+
 		void vdu_print(char c, bool usePeek);
 		void vdu_colour();
 		void vdu_gcol();
@@ -542,6 +544,7 @@ void VDUStreamProcessor::sendMouseData(MouseDelta * delta = nullptr) {
 	};
 	send_packet(PACKET_MOUSE, sizeof packet, packet);
 }
+
 // Process all available commands from the stream
 //
 void VDUStreamProcessor::processAllAvailable() {
@@ -554,9 +557,40 @@ void VDUStreamProcessor::processAllAvailable() {
 // Process next command from the stream
 //
 void VDUStreamProcessor::processNext() {
-	if (byteAvailable()) {
-		flushEcho();
-		vdu(readByte());
+	if (getContext()->checkForVSYNC()) {
+		bufferCallCallbacks(CALLBACK_VSYNC);
+	}
+
+	handleKeyboardAndMouse();
+	doCursorFlash();
+
+	switch (getContext()->getProcessorState()) {
+		case VDUProcessorState::Active:
+			// process next byte, if available
+			if (byteAvailable()) {
+				hideCursor();
+				flushEcho();
+				vdu(readByte());
+				if (!byteAvailable()) {
+					showCursor();
+				}
+			}
+			break;
+		case VDUProcessorState::WaitingForFrames:
+			// Do nothing - wait for frames to expire
+			break;
+		case VDUProcessorState::PagedModePaused:
+			if (shiftKeyPressed()) {
+				getContext()->setProcessorState(VDUProcessorState::Active);
+			}
+			break;
+		case VDUProcessorState::CtrlShiftPaused:
+			if (!shiftKeyPressed() || !ctrlKeyPressed()) {
+				getContext()->setProcessorState(VDUProcessorState::Active);
+			}
+			break;
+		default:
+			break;
 	}
 }
 
@@ -615,6 +649,53 @@ void VDUStreamProcessor::flushEcho() {
 	// debug_log("\n\r");
 	
 	echoBuffer.clear();
+}
+
+void VDUStreamProcessor::handleKeyboardAndMouse() {
+	uint8_t keycode;
+	uint8_t modifiers;
+	uint8_t vk;
+	uint8_t down;
+	MouseDelta delta;
+
+	// Send all pending keyboard events to MOS
+	while (getKeyboardKey(&keycode, &modifiers, &vk, &down)) {
+		// Handle some control keys
+		//
+		if (controlKeys && down) {
+			switch (keycode) {
+				case 2:		// printer on
+				case 3:		// printer off
+				case 6:		// VDU commands enable
+				case 7:		// Bell
+				case 12:	// CLS
+				case 14 ... 15:	// paged mode on/off
+					vdu(keycode, false);
+					break;
+				case 16:
+					// control-P toggles "printer" on R.T.Russell's BASIC
+					printerOn = !printerOn;
+			}
+		}
+		// Create and send the packet back to MOS
+		//
+		uint8_t packet[] = {
+			keycode,
+			modifiers,
+			vk,
+			down,
+		};
+		send_packet(PACKET_KEYCODE, sizeof packet, packet);
+	}
+
+	// get mouse delta, if the mouse is active
+	if (mouseMoved(&delta)) {
+		auto mouse = getMouse();
+		auto mStatus = mouse->status();
+		// update mouse cursor position if it's active
+		setMouseCursorPos(mStatus.X, mStatus.Y);
+		sendMouseData(&delta);
+	}	
 }
 
 #include "vdu.h"

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -559,6 +559,9 @@ void VDUStreamProcessor::processAllAvailable() {
 void VDUStreamProcessor::processNext() {
 	if (getContext()->checkForVSYNC()) {
 		bufferCallCallbacks(CALLBACK_VSYNC);
+		if (!byteAvailable()) {
+			getContext()->clearTempPagedMode();
+		}
 	}
 
 	handleKeyboardAndMouse();

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -268,6 +268,10 @@ void VDUStreamProcessor::vdu_sys_video() {
 			auto keyboard = getKeyboard();
 			keyboard->injectVirtualKey((VirtualKey) key, keyboard->isVKDown((VirtualKey) key), false);
 		}	break;
+		case VDP_TEMP_PAGED_MODE: {		// VDU 23, 0, &9A
+			// Set temporary paged mode
+			context->setTempPagedMode();
+		}	break;
 		case VDP_BUFFER_PRINT: {		// VDU 23, 0, &9B
 			auto bufferId = readWord_t();
 			if (bufferId == -1) return;

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -57,6 +57,7 @@ void VDUStreamProcessor::wait_eZ80() {
 			}
 		}
 	}
+	sendModeInformation();
 	debug_log("wait_eZ80: End\n\r");
 }
 


### PR DESCRIPTION
paged mode now works more like Acorn machines

page size in paged mode now ensures that 6 lines of “context” remain from the previous page, if available.  this means that if the cursor was at the top of the screen the page fills to the bottom, but if the cursor is at the bottom of the screen the 6 rows above the cursor when printing begins will be kept

the count of rows to be shown is reset when the cursor flashes, which means that paged mode only actually kicks in when a block of text is being printed

holding down `ctrl` will introduce a small delay when printing a new-line character

holding ctrl+shift pauses output at a newline

VSYNC callbacks will now get called when paged mode is pausing MOS-originated VDU commands

VDP Variables have been added that provide control over this behaviour, allowing the number of lines of context to be adjusted, and the number of frames delay when "ctrl" is being held down to be changed too

also adds in support for a command that will temporarily enable paged mode.  this can be used when you have a lot of text to display but don't want to permanently adjust the current paged-mode setting.  MOS 3 will use this to ensure that commands that potentially produce long output will get paged, specifically `help`, `dir` and `show`.

closes #39 