### PR TITLE
bump version to 2.14.0

### DIFF
--- a/video/version.h
+++ b/video/version.h
@@ -2,11 +2,12 @@
 #define VERSION_H
 
 #define		VERSION_MAJOR		2
-#define		VERSION_MINOR		13
-#define		VERSION_PATCH		1
+#define		VERSION_MINOR		14
+#define		VERSION_PATCH		0
 #define		VERSION_CANDIDATE	0			// Optional
 #define		VERSION_TYPE		"Release"	// RC, Alpha, Beta, etc.
 
-#define		VERSION_VARIANT		"Console8"
+#define		VERSION_VARIANT		"Platform"
+#define     VERSION_SUBTITLE    "Dressing Gown"
 
 #endif // VERSION_H

--- a/video/video.ino
+++ b/video/video.ino
@@ -162,6 +162,9 @@ void boot_screen() {
 	#if VERSION_CANDIDATE > 0
 		printFmt(" %s%d", VERSION_TYPE, VERSION_CANDIDATE);
 	#endif
+	#ifdef VERSION_SUBTITLE
+		printFmt(" %s", VERSION_SUBTITLE);
+	#endif
 	// Show build if defined (intended to be auto-generated string from build script from git commit hash)
 	#ifdef VERSION_BUILD
 		printFmt(" Build %s", VERSION_BUILD);


### PR DESCRIPTION
the `VERSION_VARIANT` is now “Platform” to be in-line with the new MOS 3.0 release, and to reflect our organisation name change

support for a `VERSION_SUBTITLE` added, which for this release is “Dressing Gown”, after all, can one imagine Arthur without his dressing gown?