### PR TITLE
send mode info a bit more

### DIFF
--- a/video/vdu_fonts.h
+++ b/video/vdu_fonts.h
@@ -36,6 +36,7 @@ void VDUStreamProcessor::vdu_sys_font() {
             auto field = readByte_t(); if (field == -1) return;
             auto value = readWord_t(); if (value == -1) return;
             setFontInfo(bufferId, field, value);
+            sendModeInformation();
         } break;
         case FONT_SET_NAME: {
             // either it will be: VDU 23, 0, &95, 3, bufferId; <ZeroTerminatedString>  - Set font name
@@ -53,6 +54,7 @@ void VDUStreamProcessor::vdu_sys_font() {
             } else {
                 clearFont(bufferId);
             }
+            sendModeInformation();
         } break;
         case FONT_COPY_SYSTEM: {
             // VDU 23, 0, &95, 5, bufferId;  - Copy system font
@@ -71,6 +73,7 @@ void VDUStreamProcessor::vdu_sys_font() {
                 return;
             }
             fontCopy->pointSize = FONT_AGON.pointSize;
+            sendModeInformation();
         } break;
         case FONT_SELECT_BY_NAME: {
             // VDU 23, 0, &95, &10, <ZeroTerminatedString>  - Select font by name

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -45,20 +45,22 @@ typedef union {
 //
 void VDUStreamProcessor::wait_eZ80() {
 	if (esp_reset_reason() == ESP_RST_SW) {
-		return;
-	}
-
-	debug_log("wait_eZ80: Start\n\r");
-	while (!initialised) {
-		if (byteAvailable()) {
-			auto c = readByte();	// Only handle VDU 23 packets
-			if (c == 23) {
-				vdu_sys();
+		// We only perform a s/w reset after flashing, so MOS will already be running
+		initialised = true;
+	} else {
+		debug_log("wait_eZ80: Start\n\r");
+		while (!initialised) {
+			if (byteAvailable()) {
+				auto c = readByte();	// Only handle VDU 23 packets
+				if (c == 23) {
+					vdu_sys();
+				}
 			}
 		}
+		debug_log("wait_eZ80: End\n\r");	
 	}
+
 	sendModeInformation();
-	debug_log("wait_eZ80: End\n\r");
 }
 
 // Handle SYS


### PR DESCRIPTION
before VDP 2.14.0, the boot up sequence would _always_ send mode info to MOS after `wait_eZ80` was completed.

the call to `sendModeInformation`  into the `wait_eZ80` function was moved inside `wait_eZ80`, however how this was done meant that that a software reset of the ESP32, caused by a VDP flash when MOS will still be running, did _not_ send mode information across

as the agon-flash tool was using the updated mode information as a signal that the VDP had rebooted it would then fail to recognise the VDP restart

this fixes the `wait_eZ80` behaviour, ensuring that mode info will always be sent

also adds some calls to `sendModeInformation` against a few font API functions that could, potentially, result in changed the mode info