### PR TITLE
add mouse event callbacks

### DIFF
--- a/video/agon.h
+++ b/video/agon.h
@@ -416,10 +416,17 @@
 #define COPPER_UPDATE_SIGNALLIST	3		// Update the signal list
 #define COPPER_RESET_SIGNALLIST		4		// Reset the signal list
 
-// Callback types
-#define CALLBACK_VSYNC				0		// VSync callback
-#define CALLBACK_MODE_CHANGE		1		// Mode callback
-// Future callback types may include timer, audio playback complete, etc.
+// Callback/event types
+#define CALLBACK_VSYNC				0		// VSync
+#define CALLBACK_MODE_CHANGE		1		// Mode changed
+// #define CALLBACK_KEYBOARD			2		// Keyboard event
+#define CALLBACK_MOUSE				3		// Mouse update
+// #define CALLBACK_PALETTE			4		// Palette entry changed
+// Future callback types may include...
+// * timer events (which may require metadata for timer duration, etc),
+// * audio events (a singular audio status event probably won't be enough)
+// * cursor events (movement, blink?, etc.  may need metadata to control debouncing on movement, and when events are sent)
+// * paged mode events (output paused, about to resume, setting changed)
 
 // Test/Feature flags
 #define TESTFLAG_AFFINE_TRANSFORM	1	// Affine transform test flag

--- a/video/context.h
+++ b/video/context.h
@@ -14,6 +14,7 @@
 #include "sprites.h"
 
 extern bool isFeatureFlagSet(uint16_t flag);
+extern void performMouseCallback();
 uint		lastFrameCounter = 0;			// Last frame counter for VSYNC callbacks
 
 // Support structures
@@ -1218,21 +1219,24 @@ void Context::setVariable(uint16_t var, uint16_t value) {
 		case 0x441:	// Mouse cursor enabled
 			if (value) {
 				enableMouse();
+				performMouseCallback();
 			} else {
 				disableMouse();
 			}
 			break;
 		case 0x442:	// Mouse cursor X position (pixel coords)
 			uint16_t mouseY;
-			readVariable(0x423, &mouseY);
+			readVariable(0x443, &mouseY);
 			setMousePos(value, mouseY);
 			setMouseCursorPos(value, mouseY);
+			performMouseCallback();
 			break;
 		case 0x443:	// Mouse cursor Y position
 			uint16_t mouseX;
-			readVariable(0x422, &mouseX);
+			readVariable(0x442, &mouseX);
 			setMousePos(mouseX, value);
 			setMouseCursorPos(mouseX, value);
+			performMouseCallback();
 			break;
 		case 0x444:	// Mouse cursor button status
 			break;

--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -529,7 +529,7 @@ void VDUStreamProcessor::sendMouseData(MouseDelta * delta = nullptr) {
 		buttons = mStatus.buttons.left << 0 | mStatus.buttons.right << 1 | mStatus.buttons.middle << 2;
 		wheelDelta = mStatus.wheelDelta;
 	}
-	debug_log("sendMouseData: %d %d %d %d %d %d %d %d %d %d\n\r", mouseX, mouseY, buttons, wheelDelta, deltaX, deltaY);
+	debug_log("sendMouseData: %d %d %d %d %d %d\n\r", mouseX, mouseY, buttons, wheelDelta, deltaX, deltaY);
 	uint8_t packet[] = {
 		(uint8_t) (mouseX & 0xFF),
 		(uint8_t) ((mouseX >> 8) & 0xFF),
@@ -698,6 +698,7 @@ void VDUStreamProcessor::handleKeyboardAndMouse() {
 		// update mouse cursor position if it's active
 		setMouseCursorPos(mStatus.X, mStatus.Y);
 		sendMouseData(&delta);
+		bufferCallCallbacks(CALLBACK_MOUSE);
 	}	
 }
 

--- a/video/vdu_sys.h
+++ b/video/vdu_sys.h
@@ -581,6 +581,7 @@ void VDUStreamProcessor::vdu_sys_mouse() {
 			}
 			// send mouse data (with no delta) to indicate command processed successfully
 			sendMouseData();
+			bufferCallCallbacks(CALLBACK_MOUSE);
 		}	break;
 
 		case MOUSE_DISABLE: {
@@ -624,6 +625,7 @@ void VDUStreamProcessor::vdu_sys_mouse() {
 			setMouseCursorPos(p.X, p.Y);
 
 			sendMouseData();
+			bufferCallCallbacks(CALLBACK_MOUSE);
 			debug_log("vdu_sys_mouse: set position\n\r");
 		}	break;
 

--- a/video/video.ino
+++ b/video/video.ino
@@ -343,6 +343,11 @@ bool processTerminal() {
 	return true;
 }
 
+void performMouseCallback() {
+	processor->sendMouseData();
+	processor->bufferCallCallbacks(CALLBACK_MOUSE);
+}
+
 void print(char const * text) {
 	for (auto i = 0; i < strlen(text); i++) {
 		processor->vdu(text[i], false);


### PR DESCRIPTION
new callback type for mouse events added (type 3)

a buffer registered for that event will be called when the mouse position is changed, or a “mouse enable” command is processed.  this includes changing the mouse position via `VDU 23,0,&89,4,x;y;` or via setting mouse position VDP variables

(NB currently “mouse enable” will send a mouse data packet to MOS and call the callback whether the mouse was able to be activated or not - this might be considered a bug)

a bug affecting changing the mouse position via sysvars was found and fixed: when changing X position, the Y value got zero’d, and vice versa - this was caused by the setting code using incorrect variable numbers when reading position