### PR TITLE
fix issues related to “set output stream” command

### DIFF
--- a/video/vdu_stream_processor.h
+++ b/video/vdu_stream_processor.h
@@ -561,6 +561,10 @@ void VDUStreamProcessor::processNext() {
 		bufferCallCallbacks(CALLBACK_VSYNC);
 		if (!byteAvailable()) {
 			getContext()->clearTempPagedMode();
+			// Ensure output stream changes on main VDU processor are temporary
+			if (outputStream != originalOutputStream) {
+				outputStream = originalOutputStream;
+			}
 		}
 	}
 


### PR DESCRIPTION
addresses issues with the “set output stream” buffered command

`bufferedCall` now ensures that output stream variables are correctly tracked, adjusted, and restored around buffer calls

`processNext`, the function used by the main loop to process the next command coming in from MOS, will now restore the output stream when idle if it had been changed.  this ensures that the VDU command handler that handles communication with MOS won’t get it’s output stream accidentally changed, preventing info such as keyboard packets from being sent.  this approach still allows the output to be temporarily changed, when appropraite

fixes #305
closes #304 